### PR TITLE
fix for errors when using PHP 8.0 -8.2

### DIFF
--- a/app/controller/Paste_Controller.php
+++ b/app/controller/Paste_Controller.php
@@ -52,7 +52,7 @@ class Paste_Controller {
 			$template_vars = [
 				'highlighted_content' => $Paste->highlighted_content,
 				'content' => $Paste->content,
-				'preview_html' => $Paste->preview_html,
+				'preview_html' => $Paste->preview_html ?? '',
 				'author' => $Paste->name,
 				'time' => (new DateTime('@'.$Paste->time, new DateTimeZone($time_zone))),
 				'page_title' => 'Paste by '.$Paste->name.' ('.$args['uid'].')'
@@ -81,7 +81,7 @@ class Paste_Controller {
 		$template_vars = [
 			'highlighted_content' => $Paste->highlighted_content,
 			'content' => $Paste->content,
-			'preview_html' => $Paste->preview_html,
+			'preview_html' => $Paste->preview_html ?? '',
 			'author' => $Paste->name,
 			'time' => (new DateTime('@'.$Paste->time, new DateTimeZone($time_zone))),
 		];

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "scrivo/highlight.php": "v9.18.1.9",
+        "scrivo/highlight.php": "v9.18.1.10",
         "snipworks/php-smtp": "^2.0",
         "defuse/php-encryption": "^2.3",
         "cebe/markdown": "^1.2",


### PR DESCRIPTION
Saving and viewing pastes in PHP 8.0+ current displays a "Undefined property: stdClass::$preview_html" error

Updated highlight package to fix error in PHP 8.2 "Creation of dynamic property Highlight\RegExMatch::$type is deprecated"